### PR TITLE
I'm sorry...but...

### DIFF
--- a/material-refresh.js
+++ b/material-refresh.js
@@ -454,5 +454,5 @@
 
     window.mRefresh = mRefresh;
 
-})(Zepto || jQuery);
+} ( typeof(Zepto) == "undefined" ? jQuery : Zepto ) );
 


### PR DESCRIPTION
/*
Chrome console:

typeof(Zepto)
"undefined"

var a;
undefined

a
undefined

typeof(a);
"undefined"

a == undefined
true

Zepto == undefined
VM484:2 Uncaught ReferenceError: Zepto is not defined

so.......
Sorry for that:
"Zepto || jQuery" can't run corretly on my chrome(For PC). 
*/
